### PR TITLE
Added admin settings to check concurrent sessions

### DIFF
--- a/lang/en/quizaccess_onesession.php
+++ b/lang/en/quizaccess_onesession.php
@@ -34,3 +34,7 @@ $string['pluginname'] = 'Block concurrent sessions quiz access rule';
 $string['studentinfo'] = 'Attention! It is prohibited to change device while attempting this quiz. Plaese note that after beginning of quiz attempt any connections to this quiz using other computers, devices and browsers will be blocked. Do not close the browser window until the end of attempt, otherwise you will not be able to complete this quiz.';
 $string['unlockthisattempt'] = 'Allow student to continue this attempt using other device';
 $string['unlockthisattempt_header'] = 'Block concurrent connections';
+$string['whatcheck'] = 'What is checked';
+$string['whatcheck_help'] = 'These are connection datas that will be checked to find concurrent connections';
+$string['ipaddress'] = 'IP Address';
+$string['browserinfo'] = 'Browser Infos';

--- a/rule.php
+++ b/rule.php
@@ -60,7 +60,19 @@ class quizaccess_onesession extends quiz_access_rule_base {
      * @return string
      */
     private function get_session_hash() {
-        return md5(sesskey() . getremoteaddr() . $_SERVER['HTTP_USER_AGENT']);
+        $whatcheck = get_config('quizaccess_onesession', 'whatcheck');
+
+        $sessionstring = sesskey();
+        if (!empty($whatcheck)) {
+            $checks = explode(',', $whatcheck);
+            if (in_array('ipaddress', $checks)) {
+                $sessionstring .= getremoteaddr();
+            } 
+            if (in_array('browserinfo', $checks)) {
+                $sessionstring .= $_SERVER['HTTP_USER_AGENT'];
+            } 
+        }
+        return md5($sessionstring);
     }
 
     /**

--- a/settings.php
+++ b/settings.php
@@ -30,4 +30,11 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_configcheckbox_with_advanced('quizaccess_onesession/defaultenabled',
             get_string('onesession', 'quizaccess_onesession'), '', array('value' => 0, 'adv' => true)));
+
+    $choices['ipaddress'] = get_string('ipaddress', 'quizaccess_onesession');
+    $choices['browserinfo'] = get_string('browserinfo', 'quizaccess_onesession');
+    $defaultchecks = array('ipaddress' => 1, 'browserinfo' => 1);
+    $settings->add(new admin_setting_configmulticheckbox('quizaccess_onesession/whatcheck',
+            get_string('whatcheck', 'quizaccess_onesession'), get_string('whatcheck_help', 'quizaccess_onesession'),
+            $defaultchecks, $choices));
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'quizaccess_onesession';
-$plugin->version   = 2016042800;
+$plugin->version   = 2020051600;
 $plugin->release = '1.0';
 $plugin->maturity = MATURITY_STABLE;
 $plugin->requires = 2014051200; // Moodle 2.7.


### PR DESCRIPTION
I added a setting to enable administrator a more flexible check on concurrent sessions.
Students connected with mobile phone change them ips when they change cells, this create false positive.
Now administrator can disable ip or browser info checks if needed.

HTH  